### PR TITLE
fix non unique uuids in db

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,10 @@ The following GitHub-Actions can help deploying the app:
 | src/types      | Type extensions / definitions         |
 
 To test / develop the API, a neo4j-container can be started through the [docker-compose.yml](docker-compose.yml) file.
-A root-node has to be inserted manually for the API to work.
+
+A root-node has to be inserted manually for the API to work:
+
+```cypher
+MERGE (b:User { uuid: "00000000-0000-4000-A000-000000000000", litTime: 1609459200000, lat: 50.09692895957101, lng: 8.21682929992676 });
+CREATE CONSTRAINT uuid_unique FOR (u:User) REQUIRE u.uuid IS UNIQUE;
+```

--- a/src/controller/TreeController.ts
+++ b/src/controller/TreeController.ts
@@ -55,10 +55,12 @@ export const create = async (
 	session
 		.writeTransaction((txc) =>
 			txc.run(
-				`MATCH
-				(a:User)
-				WHERE a.uuid = $parentUuid
-				CREATE (a)-[:LIGHTS]->(b:User { uuid: $childUuid, litTime: $litTime, lat: $lat, lng: $lng })
+				`MATCH (a:User) WHERE a.uuid = $parentUuid // find parent node
+				MERGE (b:User {uuid: $childUuid}) // create child node if not exists
+				SET b.litTime = coalesce(b.litTime, $litTime) // set litTime if not exists
+				SET b.lat = coalesce(b.lat, $lat) // set lat if not exists
+				SET b.lng = coalesce(b.lng, $lng) // set lng if not exists
+				MERGE (a)-[:LIGHTS]->(b) // create link if not exists
 				RETURN a,b`,
 				{
 					parentUuid: uuidParent,


### PR DESCRIPTION
Fixes error, that inserted data twice if app requests two insertions for the same device uuid
(happens because the qr-scanner triggers multiple times)

Changed cypher code does not modify the data in case the uuid is known already, but still returns the parent/child pair.
